### PR TITLE
[Just to run Actions] add-ons: Only include last Change-Id in the squashed commit

### DIFF
--- a/weblate/addons/git.py
+++ b/weblate/addons/git.py
@@ -93,12 +93,12 @@ class GitSquashAddon(BaseAddon):
 
             trailer_lines = set()
             seen_change_id = False
-            for trailer in repository.execute(command).split("\n"):
+            for trailer in reversed(repository.execute(command).split("\n")):
                 # Skip blank lines
                 if not trailer.strip():
                     continue
 
-                # Pick only first Change-Id, there suppose to be only one in the
+                # Pick the last Change-Id, there suppose to be only one in the
                 # commit (used by Gerrit)
                 if trailer.startswith("Change-Id:"):
                     if seen_change_id:


### PR DESCRIPTION
Picking the first ends up duplicating commits, every time it gets squashed it gets a new Change-Id.

Pick the last instead to hopefully try and avoid that.

Fixes: 2f93229b51356c5c58afab979fa68a04c79c9673

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code.
-->

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added documentation to describe my feature.
- [ ] I have squashed my commits into logic units.
- [ ] I have described the changes in the commit messages.

## Other information

<!--
Any other information that is important to this PR such as screenshots of how
the component looks before and after the change.
-->
